### PR TITLE
Populate dashboard metrics via API client

### DIFF
--- a/src/assets/static/js/api-client.js
+++ b/src/assets/static/js/api-client.js
@@ -1,0 +1,14 @@
+async function request(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error('Request failed: ' + response.status);
+  }
+  return response.json();
+}
+
+window.apiClient = {
+  listAgents: () => request('/api/v1/admin/agents'),
+  listPanels: () => request('/api/v1/admin/panels'),
+  listServices: () => request('/api/v1/admin/services'),
+  listSettings: () => request('/api/v1/admin/settings'),
+};

--- a/src/assets/static/js/pages/dashboard.js
+++ b/src/assets/static/js/pages/dashboard.js
@@ -1,3 +1,23 @@
+async function loadDashboardMetrics() {
+  try {
+    const [agents, panels, services, settings] = await Promise.all([
+      window.apiClient.listAgents(),
+      window.apiClient.listPanels(),
+      window.apiClient.listServices(),
+      window.apiClient.listSettings(),
+    ]);
+
+    document.getElementById('agents-count').textContent = agents.length;
+    document.getElementById('panels-count').textContent = panels.length;
+    document.getElementById('services-count').textContent = services.length;
+    document.getElementById('settings-count').textContent = settings.length;
+  } catch (error) {
+    console.error('Failed to load dashboard metrics', error);
+  }
+}
+
+loadDashboardMetrics();
+
 var optionsProfileVisit = {
   annotations: {
     position: "back",

--- a/src/index.html
+++ b/src/index.html
@@ -25,8 +25,8 @@
                                     </div>
                                 </div>
                                 <div class="col-md-8 col-lg-12 col-xl-12 col-xxl-7">
-                                    <h6 class="text-muted font-semibold">Profile Views</h6>
-                                    <h6 class="font-extrabold mb-0">112.000</h6>
+                                    <h6 class="text-muted font-semibold">Agents</h6>
+                                    <h6 class="font-extrabold mb-0" id="agents-count">0</h6>
                                 </div>
                             </div> 
                         </div>
@@ -42,8 +42,8 @@
                                     </div>
                                 </div>
                                 <div class="col-md-8 col-lg-12 col-xl-12 col-xxl-7">
-                                    <h6 class="text-muted font-semibold">Followers</h6>
-                                    <h6 class="font-extrabold mb-0">183.000</h6>
+                                    <h6 class="text-muted font-semibold">Panels</h6>
+                                    <h6 class="font-extrabold mb-0" id="panels-count">0</h6>
                                 </div>
                             </div>
                         </div>
@@ -59,8 +59,8 @@
                                     </div>
                                 </div>
                                 <div class="col-md-8 col-lg-12 col-xl-12 col-xxl-7">
-                                    <h6 class="text-muted font-semibold">Following</h6>
-                                    <h6 class="font-extrabold mb-0">80.000</h6>
+                                    <h6 class="text-muted font-semibold">Services</h6>
+                                    <h6 class="font-extrabold mb-0" id="services-count">0</h6>
                                 </div>
                             </div>
                         </div>
@@ -76,8 +76,8 @@
                                     </div>
                                 </div>
                                 <div class="col-md-8 col-lg-12 col-xl-12 col-xxl-7">
-                                    <h6 class="text-muted font-semibold">Saved Post</h6>
-                                    <h6 class="font-extrabold mb-0">112</h6>
+                                    <h6 class="text-muted font-semibold">Settings</h6>
+                                    <h6 class="font-extrabold mb-0" id="settings-count">0</h6>
                                 </div>
                             </div>
                         </div>
@@ -319,6 +319,7 @@
 {% endblock %}
 {% block js %}
 <!-- Need: Apexcharts -->
+<script src="assets/static/js/api-client.js"></script>
 <script src="assets/extensions/apexcharts/apexcharts.min.js"></script>
 <script src="assets/static/js/pages/dashboard.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- replace placeholder dashboard cards with counts for agents, panels, services, and settings
- add a small API client and use it to fetch metrics
- load metrics asynchronously within the dashboard script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: can't be bundled without type="module" attribute)*

------
https://chatgpt.com/codex/tasks/task_b_68c6a8571c648328b3bc99ec0d4c9e56