### PR TITLE
Implement login flow with token persistence

### DIFF
--- a/src/assets/js/api.js
+++ b/src/assets/js/api.js
@@ -1,9 +1,11 @@
 import { API_BASE_URL } from './config.js';
 
-let authToken = null;
+const TOKEN_KEY = 'auth_token';
+let authToken = localStorage.getItem(TOKEN_KEY);
 
 export function setToken(token) {
   authToken = token;
+  localStorage.setItem(TOKEN_KEY, token);
 }
 
 export function getToken() {
@@ -12,6 +14,7 @@ export function getToken() {
 
 export function clearToken() {
   authToken = null;
+  localStorage.removeItem(TOKEN_KEY);
 }
 
 async function request(method, endpoint, data) {

--- a/src/assets/static/js/helper/auth.js
+++ b/src/assets/static/js/helper/auth.js
@@ -1,0 +1,16 @@
+import api from '../../../js/api.js';
+
+// Redirect to login if no token is present
+if (!api.getToken()) {
+  window.location.href = 'auth-login.html';
+}
+
+const logoutBtn = document.getElementById('logout-button');
+if (logoutBtn) {
+  logoutBtn.addEventListener('click', (e) => {
+    e.preventDefault();
+    api.clearToken();
+    window.location.href = 'auth-login.html';
+  });
+}
+

--- a/src/assets/static/js/pages/dashboard.js
+++ b/src/assets/static/js/pages/dashboard.js
@@ -1,4 +1,4 @@
-import { get } from '../../js/api.js';
+import { get } from '../../../js/api.js';
 
 async function loadDashboardMetrics() {
   try {
@@ -187,3 +187,4 @@ chartIndia.render()
 chartEurope.render()
 chartProfileVisit.render()
 chartVisitorsProfile.render()
+

--- a/src/assets/static/js/pages/login.js
+++ b/src/assets/static/js/pages/login.js
@@ -1,0 +1,21 @@
+import api from '../../../js/api.js';
+
+const form = document.getElementById('login-form');
+
+if (form) {
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    try {
+      const res = await api.post('/admin/token', { username, password });
+      const token = res.token || res.access_token;
+      if (!token) throw new Error('No token returned');
+      api.setToken(token);
+      window.location.href = 'index.html';
+    } catch (err) {
+      alert('Login failed');
+    }
+  });
+}
+

--- a/src/auth-login.html
+++ b/src/auth-login.html
@@ -11,15 +11,15 @@
             <h1 class="auth-title">Log in.</h1>
             <p class="auth-subtitle mb-5">Log in with your data that you entered during registration.</p>
 
-            <form action="index.html">
+            <form id="login-form">
                 <div class="form-group position-relative has-icon-left mb-4">
-                    <input type="text" class="form-control form-control-xl" placeholder="Username">
+                    <input id="username" type="text" class="form-control form-control-xl" placeholder="Username">
                     <div class="form-control-icon">
                         <i class="bi bi-person"></i>
                     </div>
                 </div>
                 <div class="form-group position-relative has-icon-left mb-4">
-                    <input type="password" class="form-control form-control-xl" placeholder="Password">
+                    <input id="password" type="password" class="form-control form-control-xl" placeholder="Password">
                     <div class="form-control-icon">
                         <i class="bi bi-shield-lock"></i>
                     </div>
@@ -30,7 +30,7 @@
                         Keep me logged in
                     </label>
                 </div>
-                <button class="btn btn-primary btn-block btn-lg shadow-lg mt-5">Log in</button>
+                <button type="submit" class="btn btn-primary btn-block btn-lg shadow-lg mt-5">Log in</button>
             </form>
             <div class="text-center mt-5 text-lg fs-4">
                 <p class="text-gray-600">Don't have an account? <a href="auth-register.html" class="font-bold">Sign
@@ -45,4 +45,5 @@
         </div>
     </div>
 </div>
+<script type="module" src="assets/static/js/pages/login.js"></script>
 {% endblock %}

--- a/src/layouts/master.html
+++ b/src/layouts/master.html
@@ -38,6 +38,8 @@
     <script src="assets/compiled/js/app.js"></script>
     {% endif %}
 
+    <script type="module" src="assets/static/js/helper/auth.js"></script>
+
     {% block js %}{% endblock %}
 </body>
 

--- a/src/layouts/sidebar.html
+++ b/src/layouts/sidebar.html
@@ -70,6 +70,12 @@
 
             </li>
             {% endif %}{% endfor %}
+            <li class="sidebar-item">
+                <a href="#" class="sidebar-link" id="logout-button">
+                    <i class="bi bi-box-arrow-right"></i>
+                    <span>Logout</span>
+                </a>
+            </li>
         </ul>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- store auth token in localStorage and attach Authorization headers on API calls
- create login page that requests `/api/v1/admin/token`
- add global auth helper and sidebar logout link

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c6aa2d17808328916dddcf399dc7a7