### PR TITLE
Add CRUD API pages

### DIFF
--- a/src/agents.html
+++ b/src/agents.html
@@ -10,20 +10,75 @@
 <div class="page-content">
   <section class="row">
     <div class="col-12">
+      <button id="agents-list" class="btn btn-primary mb-3">List Agents</button>
       <pre id="agents-data"></pre>
+      <hr/>
+      <h5>Create</h5>
+      <form id="agents-create" class="mb-3">
+        <textarea id="agents-create-json" class="form-control" rows="3" placeholder='{"name":"Example"}'></textarea>
+        <button type="submit" class="btn btn-success mt-2">Create</button>
+      </form>
+      <h5>Update</h5>
+      <form id="agents-update" class="mb-3">
+        <input id="agents-update-id" class="form-control mb-2" placeholder="ID"/>
+        <textarea id="agents-update-json" class="form-control" rows="3" placeholder='{"name":"Updated"}'></textarea>
+        <button type="submit" class="btn btn-warning mt-2">Update</button>
+      </form>
+      <h5>Delete</h5>
+      <form id="agents-delete">
+        <input id="agents-delete-id" class="form-control mb-2" placeholder="ID"/>
+        <button type="submit" class="btn btn-danger">Delete</button>
+      </form>
     </div>
   </section>
 </div>
 {% endblock %}
 
-{% block scripts %}
+{% block js %}
 <script type="module">
-import { get } from './assets/js/api.js';
+import { get, post, put, del } from './assets/js/api.js';
 
-get('/admin/agents')
-  .then(data => {
-    document.getElementById('agents-data').textContent = JSON.stringify(data, null, 2);
-  })
-  .catch(err => console.error(err));
+const base = '/admin/agents';
+const output = document.getElementById('agents-data');
+
+function refresh() {
+  get(base).then(data => {
+    output.textContent = JSON.stringify(data, null, 2);
+  }).catch(err => console.error(err));
+}
+
+document.getElementById('agents-list').addEventListener('click', e => {
+  e.preventDefault();
+  refresh();
+});
+
+document.getElementById('agents-create').addEventListener('submit', e => {
+  e.preventDefault();
+  try {
+    const payload = JSON.parse(document.getElementById('agents-create-json').value || '{}');
+    post(base, payload).then(refresh);
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+document.getElementById('agents-update').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('agents-update-id').value;
+  try {
+    const payload = JSON.parse(document.getElementById('agents-update-json').value || '{}');
+    put(`${base}/${id}`, payload).then(refresh);
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+document.getElementById('agents-delete').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('agents-delete-id').value;
+  del(`${base}/${id}`).then(refresh).catch(err => console.error(err));
+});
+
+refresh();
 </script>
 {% endblock %}

--- a/src/panels.html
+++ b/src/panels.html
@@ -10,20 +10,75 @@
 <div class="page-content">
   <section class="row">
     <div class="col-12">
+      <button id="panels-list" class="btn btn-primary mb-3">List Panels</button>
       <pre id="panels-data"></pre>
+      <hr/>
+      <h5>Create</h5>
+      <form id="panels-create" class="mb-3">
+        <textarea id="panels-create-json" class="form-control" rows="3" placeholder='{"name":"Example"}'></textarea>
+        <button type="submit" class="btn btn-success mt-2">Create</button>
+      </form>
+      <h5>Update</h5>
+      <form id="panels-update" class="mb-3">
+        <input id="panels-update-id" class="form-control mb-2" placeholder="ID"/>
+        <textarea id="panels-update-json" class="form-control" rows="3" placeholder='{"name":"Updated"}'></textarea>
+        <button type="submit" class="btn btn-warning mt-2">Update</button>
+      </form>
+      <h5>Delete</h5>
+      <form id="panels-delete">
+        <input id="panels-delete-id" class="form-control mb-2" placeholder="ID"/>
+        <button type="submit" class="btn btn-danger">Delete</button>
+      </form>
     </div>
   </section>
 </div>
 {% endblock %}
 
-{% block scripts %}
+{% block js %}
 <script type="module">
-import { get } from './assets/js/api.js';
+import { get, post, put, del } from './assets/js/api.js';
 
-get('/admin/panels')
-  .then(data => {
-    document.getElementById('panels-data').textContent = JSON.stringify(data, null, 2);
-  })
-  .catch(err => console.error(err));
+const base = '/admin/panels';
+const output = document.getElementById('panels-data');
+
+function refresh() {
+  get(base).then(data => {
+    output.textContent = JSON.stringify(data, null, 2);
+  }).catch(err => console.error(err));
+}
+
+document.getElementById('panels-list').addEventListener('click', e => {
+  e.preventDefault();
+  refresh();
+});
+
+document.getElementById('panels-create').addEventListener('submit', e => {
+  e.preventDefault();
+  try {
+    const payload = JSON.parse(document.getElementById('panels-create-json').value || '{}');
+    post(base, payload).then(refresh);
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+document.getElementById('panels-update').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('panels-update-id').value;
+  try {
+    const payload = JSON.parse(document.getElementById('panels-update-json').value || '{}');
+    put(`${base}/${id}`, payload).then(refresh);
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+document.getElementById('panels-delete').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('panels-delete-id').value;
+  del(`${base}/${id}`).then(refresh).catch(err => console.error(err));
+});
+
+refresh();
 </script>
 {% endblock %}

--- a/src/services.html
+++ b/src/services.html
@@ -10,20 +10,75 @@
 <div class="page-content">
   <section class="row">
     <div class="col-12">
+      <button id="services-list" class="btn btn-primary mb-3">List Services</button>
       <pre id="services-data"></pre>
+      <hr/>
+      <h5>Create</h5>
+      <form id="services-create" class="mb-3">
+        <textarea id="services-create-json" class="form-control" rows="3" placeholder='{"name":"Example"}'></textarea>
+        <button type="submit" class="btn btn-success mt-2">Create</button>
+      </form>
+      <h5>Update</h5>
+      <form id="services-update" class="mb-3">
+        <input id="services-update-id" class="form-control mb-2" placeholder="ID"/>
+        <textarea id="services-update-json" class="form-control" rows="3" placeholder='{"name":"Updated"}'></textarea>
+        <button type="submit" class="btn btn-warning mt-2">Update</button>
+      </form>
+      <h5>Delete</h5>
+      <form id="services-delete">
+        <input id="services-delete-id" class="form-control mb-2" placeholder="ID"/>
+        <button type="submit" class="btn btn-danger">Delete</button>
+      </form>
     </div>
   </section>
 </div>
 {% endblock %}
 
-{% block scripts %}
+{% block js %}
 <script type="module">
-import { get } from './assets/js/api.js';
+import { get, post, put, del } from './assets/js/api.js';
 
-get('/admin/services')
-  .then(data => {
-    document.getElementById('services-data').textContent = JSON.stringify(data, null, 2);
-  })
-  .catch(err => console.error(err));
+const base = '/admin/services';
+const output = document.getElementById('services-data');
+
+function refresh() {
+  get(base).then(data => {
+    output.textContent = JSON.stringify(data, null, 2);
+  }).catch(err => console.error(err));
+}
+
+document.getElementById('services-list').addEventListener('click', e => {
+  e.preventDefault();
+  refresh();
+});
+
+document.getElementById('services-create').addEventListener('submit', e => {
+  e.preventDefault();
+  try {
+    const payload = JSON.parse(document.getElementById('services-create-json').value || '{}');
+    post(base, payload).then(refresh);
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+document.getElementById('services-update').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('services-update-id').value;
+  try {
+    const payload = JSON.parse(document.getElementById('services-update-json').value || '{}');
+    put(`${base}/${id}`, payload).then(refresh);
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+document.getElementById('services-delete').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('services-delete-id').value;
+  del(`${base}/${id}`).then(refresh).catch(err => console.error(err));
+});
+
+refresh();
 </script>
 {% endblock %}

--- a/src/settings.html
+++ b/src/settings.html
@@ -10,20 +10,75 @@
 <div class="page-content">
   <section class="row">
     <div class="col-12">
+      <button id="settings-list" class="btn btn-primary mb-3">List Settings</button>
       <pre id="settings-data"></pre>
+      <hr/>
+      <h5>Create</h5>
+      <form id="settings-create" class="mb-3">
+        <textarea id="settings-create-json" class="form-control" rows="3" placeholder='{"name":"Example"}'></textarea>
+        <button type="submit" class="btn btn-success mt-2">Create</button>
+      </form>
+      <h5>Update</h5>
+      <form id="settings-update" class="mb-3">
+        <input id="settings-update-id" class="form-control mb-2" placeholder="ID"/>
+        <textarea id="settings-update-json" class="form-control" rows="3" placeholder='{"name":"Updated"}'></textarea>
+        <button type="submit" class="btn btn-warning mt-2">Update</button>
+      </form>
+      <h5>Delete</h5>
+      <form id="settings-delete">
+        <input id="settings-delete-id" class="form-control mb-2" placeholder="ID"/>
+        <button type="submit" class="btn btn-danger">Delete</button>
+      </form>
     </div>
   </section>
 </div>
 {% endblock %}
 
-{% block scripts %}
+{% block js %}
 <script type="module">
-import { get } from './assets/js/api.js';
+import { get, post, put, del } from './assets/js/api.js';
 
-get('/admin/settings')
-  .then(data => {
-    document.getElementById('settings-data').textContent = JSON.stringify(data, null, 2);
-  })
-  .catch(err => console.error(err));
+const base = '/admin/settings';
+const output = document.getElementById('settings-data');
+
+function refresh() {
+  get(base).then(data => {
+    output.textContent = JSON.stringify(data, null, 2);
+  }).catch(err => console.error(err));
+}
+
+document.getElementById('settings-list').addEventListener('click', e => {
+  e.preventDefault();
+  refresh();
+});
+
+document.getElementById('settings-create').addEventListener('submit', e => {
+  e.preventDefault();
+  try {
+    const payload = JSON.parse(document.getElementById('settings-create-json').value || '{}');
+    post(base, payload).then(refresh);
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+document.getElementById('settings-update').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('settings-update-id').value;
+  try {
+    const payload = JSON.parse(document.getElementById('settings-update-json').value || '{}');
+    put(`${base}/${id}`, payload).then(refresh);
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+document.getElementById('settings-delete').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('settings-delete-id').value;
+  del(`${base}/${id}`).then(refresh).catch(err => console.error(err));
+});
+
+refresh();
 </script>
 {% endblock %}

--- a/src/users.html
+++ b/src/users.html
@@ -10,20 +10,75 @@
 <div class="page-content">
   <section class="row">
     <div class="col-12">
+      <button id="users-list" class="btn btn-primary mb-3">List Users</button>
       <pre id="users-data"></pre>
+      <hr/>
+      <h5>Create</h5>
+      <form id="users-create" class="mb-3">
+        <textarea id="users-create-json" class="form-control" rows="3" placeholder='{"name":"Example"}'></textarea>
+        <button type="submit" class="btn btn-success mt-2">Create</button>
+      </form>
+      <h5>Update</h5>
+      <form id="users-update" class="mb-3">
+        <input id="users-update-id" class="form-control mb-2" placeholder="ID"/>
+        <textarea id="users-update-json" class="form-control" rows="3" placeholder='{"name":"Updated"}'></textarea>
+        <button type="submit" class="btn btn-warning mt-2">Update</button>
+      </form>
+      <h5>Delete</h5>
+      <form id="users-delete">
+        <input id="users-delete-id" class="form-control mb-2" placeholder="ID"/>
+        <button type="submit" class="btn btn-danger">Delete</button>
+      </form>
     </div>
   </section>
 </div>
 {% endblock %}
 
-{% block scripts %}
+{% block js %}
 <script type="module">
-import { get } from './assets/js/api.js';
+import { get, post, put, del } from './assets/js/api.js';
 
-get('/users')
-  .then(data => {
-    document.getElementById('users-data').textContent = JSON.stringify(data, null, 2);
-  })
-  .catch(err => console.error(err));
+const base = '/users';
+const output = document.getElementById('users-data');
+
+function refresh() {
+  get(base).then(data => {
+    output.textContent = JSON.stringify(data, null, 2);
+  }).catch(err => console.error(err));
+}
+
+document.getElementById('users-list').addEventListener('click', e => {
+  e.preventDefault();
+  refresh();
+});
+
+document.getElementById('users-create').addEventListener('submit', e => {
+  e.preventDefault();
+  try {
+    const payload = JSON.parse(document.getElementById('users-create-json').value || '{}');
+    post(base, payload).then(refresh);
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+document.getElementById('users-update').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('users-update-id').value;
+  try {
+    const payload = JSON.parse(document.getElementById('users-update-json').value || '{}');
+    put(`${base}/${id}`, payload).then(refresh);
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+document.getElementById('users-delete').addEventListener('submit', e => {
+  e.preventDefault();
+  const id = document.getElementById('users-delete-id').value;
+  del(`${base}/${id}`).then(refresh).catch(err => console.error(err));
+});
+
+refresh();
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- implement CRUD forms using API client for agents, panels, services, settings, and users pages
- ensure navigation menu lists agents, panels, services, settings and users

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68c6abccdbb083288c1863b9607a229f